### PR TITLE
noteitem.js component was incorrectly named inside the component

### DIFF
--- a/frontend/src/components/NoteItem.js
+++ b/frontend/src/components/NoteItem.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
-const NoteList = (props) => (
+const NoteItem = (props) => (
   <li>
     <h2>Title</h2>
     <p>Caption...</p>
   </li>
 );
 
-export default NoteList;
+export default NoteItem;


### PR DESCRIPTION
NoteItem.js had a function component inside it named NoteList and was `export default NoteList`. so when importing NoteItem from './NoteItem.js' the correct component was being imported, but was incorrectly name in the component and would thus display confusing component structure in react dev tools.
This PR fixes that and renames the NoteItem function from `const NoteList ...` to to `const NoteItem ...`